### PR TITLE
Call renderNoteLabel for all keys, even if it doesn't have a keyboardShortcut

### DIFF
--- a/src/Piano.js
+++ b/src/Piano.js
@@ -26,17 +26,18 @@ class Piano extends React.Component {
   };
 
   static defaultProps = {
-    renderNoteLabel: ({ keyboardShortcut, midiNumber, isActive, isAccidental }) => (
-      keyboardShortcut ? <div
-        className={classNames('ReactPiano__NoteLabel', {
-          'ReactPiano__NoteLabel--active': isActive,
-          'ReactPiano__NoteLabel--accidental': isAccidental,
-          'ReactPiano__NoteLabel--natural': !isAccidental,
-        })}
-      >
-        {keyboardShortcut}
-      </div> : null
-    ),
+    renderNoteLabel: ({ keyboardShortcut, midiNumber, isActive, isAccidental }) =>
+      keyboardShortcut ? (
+        <div
+          className={classNames('ReactPiano__NoteLabel', {
+            'ReactPiano__NoteLabel--active': isActive,
+            'ReactPiano__NoteLabel--accidental': isAccidental,
+            'ReactPiano__NoteLabel--natural': !isAccidental,
+          })}
+        >
+          {keyboardShortcut}
+        </div>
+      ) : null,
   };
 
   constructor(props) {

--- a/src/Piano.js
+++ b/src/Piano.js
@@ -27,7 +27,7 @@ class Piano extends React.Component {
 
   static defaultProps = {
     renderNoteLabel: ({ keyboardShortcut, midiNumber, isActive, isAccidental }) => (
-      <div
+      keyboardShortcut ? <div
         className={classNames('ReactPiano__NoteLabel', {
           'ReactPiano__NoteLabel--active': isActive,
           'ReactPiano__NoteLabel--accidental': isAccidental,
@@ -35,7 +35,7 @@ class Piano extends React.Component {
         })}
       >
         {keyboardShortcut}
-      </div>
+      </div> : null
     ),
   };
 
@@ -183,9 +183,6 @@ class Piano extends React.Component {
 
   renderNoteLabel = ({ midiNumber, isActive, isAccidental }) => {
     const keyboardShortcut = this.getKeyForMidiNumber(midiNumber);
-    if (!keyboardShortcut) {
-      return null;
-    }
     return this.props.renderNoteLabel({ keyboardShortcut, midiNumber, isActive, isAccidental });
   };
 

--- a/src/Piano.test.js
+++ b/src/Piano.test.js
@@ -3,7 +3,6 @@ import { mount } from 'enzyme';
 
 import Piano from './Piano';
 import MidiNumbers from './MidiNumbers';
-import KeyboardShortcuts from './KeyboardShortcuts';
 
 let eventListenerCallbacks;
 let spyConsoleError;
@@ -216,6 +215,60 @@ describe('<Piano />', () => {
       );
 
       expect(wrapper.find('.ReactPiano__Keyboard').hasClass('Hello')).toBe(true);
+    });
+  });
+
+  describe('renderNoteLabel', () => {
+    test('default value has correct behavior', () => {
+      const keyboardShortcuts = [{ key: 'a', midiNumber: MidiNumbers.fromNote('c3') }];
+      const wrapper = mount(
+        <Piano
+          noteRange={{ first: MidiNumbers.fromNote('c3'), last: MidiNumbers.fromNote('c4') }}
+          onPlayNote={() => {}}
+          onStopNote={() => {}}
+          keyboardShortcuts={keyboardShortcuts}
+        />,
+      );
+
+      // First key should have label with correct classes
+      const firstKey = wrapper.find('.ReactPiano__Key').at(0);
+      expect(firstKey.find('.ReactPiano__NoteLabel').text()).toBe('a');
+      expect(
+        firstKey.find('.ReactPiano__NoteLabel').hasClass('ReactPiano__NoteLabel--natural'),
+      ).toBe(true);
+
+      // Second key should not have label
+      const secondKey = wrapper.find('.ReactPiano__Key').at(1);
+      expect(secondKey.find('.ReactPiano__NoteLabel').exists()).toBe(false);
+    });
+    test('works for keys with and without shortcuts', () => {
+      const keyboardShortcuts = [{ key: 'a', midiNumber: MidiNumbers.fromNote('c3') }];
+      const wrapper = mount(
+        <Piano
+          noteRange={{ first: MidiNumbers.fromNote('c3'), last: MidiNumbers.fromNote('c4') }}
+          onPlayNote={() => {}}
+          onStopNote={() => {}}
+          keyboardShortcuts={keyboardShortcuts}
+          renderNoteLabel={({ keyboardShortcut, midiNumber, isActive, isAccidental }) => {
+            return (
+              <div>
+                <div className="label-keyboardShortcut">{keyboardShortcut}</div>
+                <div className="label-midiNumber">{midiNumber}</div>
+              </div>
+            );
+          }}
+        />,
+      );
+
+      // First key should have midinumber and keyboard shortcut labels
+      const firstKey = wrapper.find('.ReactPiano__Key').at(0);
+      expect(firstKey.find('.label-midiNumber').text()).toBe(`${MidiNumbers.fromNote('c3')}`);
+      expect(firstKey.find('.label-keyboardShortcut').text()).toBe('a');
+
+      // Second key should only have midinumber label
+      const secondKey = wrapper.find('.ReactPiano__Key').at(1);
+      expect(secondKey.find('.label-midiNumber').text()).toBe(`${MidiNumbers.fromNote('db3')}`);
+      expect(secondKey.find('.label-keyboardShortcut').text()).toBe('');
     });
   });
 });


### PR DESCRIPTION
fixes #22 