### PR TITLE
Use babel env target to compile ES6 features to ES5 to fix create-react-app prod build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
     [
       "@babel/env",
       {
-        "targets": { "node": "6" }
+        "targets": { "node": "6", "browsers": [">0.25%"] }
       }
     ],
     "@babel/preset-react"


### PR DESCRIPTION
Issue: was hitting [this issue](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify) when running `yarn run build` in /demo.

Fix this by targeting browsers in .babelrc so that ES6 features are transpiled to ES5 and create-react-app doesn't break when attempting to uglify the production JS.


