### PR TITLE
Fix activeNotes behavior, and add onPlayNoteInput/onStopNoteInput props

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ react-piano does not implement audio playback of each note, so you have to imple
 | `className` | String | A className to add to the component. |
 | `disabled` | Boolean | Whether to show disabled state. Useful when audio sounds need to be asynchronously loaded. |
 | `keyboardShortcuts` | Array of object | An array of form `[{ key: 'a', midiNumber: 48 }, ...]`, where `key` is a `keyEvent.key` value. You can generate this using `KeyboardShortcuts.create`, or use your own method to generate it. You can omit it if you don't want to use keyboard shortcuts. **Note:** this shouldn't be generated inline in JSX because it can cause problems when diffing for shortcut changes. |
+| `onPlayNoteInput` | Function | `(midiNumber, { prevActiveNotes }) => void` function that fires whenever a play-note event is fired. Can use `prevActiveNotes` to record notes. |
+| `onStopNoteInput` | Function | `(midiNumber, { prevActiveNotes }) => void` function that fires whenever a stop-note event is fired. Can use `prevActiveNotes` to record notes. |
 
 ## Customizing styles
 

--- a/src/ControlledPiano.js
+++ b/src/ControlledPiano.js
@@ -40,14 +40,10 @@ class ControlledPiano extends React.Component {
       ) : null,
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      isMouseDown: false,
-      useTouchEvents: false,
-    };
-  }
+  state = {
+    isMouseDown: false,
+    useTouchEvents: false,
+  };
 
   componentDidMount() {
     window.addEventListener('keydown', this.onKeyDown);

--- a/src/Piano.js
+++ b/src/Piano.js
@@ -47,9 +47,15 @@ class Piano extends React.Component {
     if (this.props.onPlayNoteInput) {
       this.props.onPlayNoteInput(midiNumber, { prevActiveNotes: this.state.activeNotes });
     }
-    this.setState((prevState) => ({
-      activeNotes: prevState.activeNotes.concat(midiNumber),
-    }));
+    this.setState((prevState) => {
+      // Don't append note to activeNotes if it's already present
+      if (prevState.activeNotes.includes(midiNumber)) {
+        return null;
+      }
+      return {
+        activeNotes: prevState.activeNotes.concat(midiNumber),
+      };
+    });
   };
 
   handleStopNoteInput = (midiNumber) => {

--- a/src/Piano.js
+++ b/src/Piano.js
@@ -36,7 +36,7 @@ class Piano extends React.Component {
       this.state.activeNotes !== this.props.activeNotes
     ) {
       this.setState({
-        activeNotes: this.props.activeNotes,
+        activeNotes: this.props.activeNotes || [],
       });
     }
   }

--- a/src/Piano.js
+++ b/src/Piano.js
@@ -11,6 +11,8 @@ class Piano extends React.Component {
     activeNotes: PropTypes.arrayOf(PropTypes.number.isRequired),
     playNote: PropTypes.func.isRequired,
     stopNote: PropTypes.func.isRequired,
+    onPlayNoteInput: PropTypes.func,
+    onStopNoteInput: PropTypes.func,
     renderNoteLabel: PropTypes.func,
     className: PropTypes.string,
     disabled: PropTypes.bool,
@@ -42,19 +44,25 @@ class Piano extends React.Component {
   }
 
   handlePlayNoteInput = (midiNumber) => {
+    if (this.props.onPlayNoteInput) {
+      this.props.onPlayNoteInput(midiNumber, { prevActiveNotes: this.state.activeNotes });
+    }
     this.setState((prevState) => ({
       activeNotes: prevState.activeNotes.concat(midiNumber),
     }));
   };
 
   handleStopNoteInput = (midiNumber) => {
+    if (this.props.onStopNoteInput) {
+      this.props.onStopNoteInput(midiNumber, { prevActiveNotes: this.state.activeNotes });
+    }
     this.setState((prevState) => ({
       activeNotes: prevState.activeNotes.filter((note) => midiNumber !== note),
     }));
   };
 
   render() {
-    const { activeNotes, ...otherProps } = this.props;
+    const { activeNotes, onPlayNoteInput, onStopNoteInput, ...otherProps } = this.props;
     return (
       <ControlledPiano
         activeNotes={this.state.activeNotes}

--- a/src/Piano.js
+++ b/src/Piano.js
@@ -54,12 +54,13 @@ class Piano extends React.Component {
   };
 
   render() {
+    const { activeNotes, ...otherProps } = this.props;
     return (
       <ControlledPiano
         activeNotes={this.state.activeNotes}
         onPlayNoteInput={this.handlePlayNoteInput}
         onStopNoteInput={this.handleStopNoteInput}
-        {...this.props}
+        {...otherProps}
       />
     );
   }


### PR DESCRIPTION
* Fixes the case when things would break when props.activeNotes = null
* Fixes case when Piano's activeNotes state wasn't being updated correctly
* Fixes repeated keypress inputs appending notes to activeNotes indefinitely
* Adds `onPlayNoteInput` and `onStopNoteInput` props to Piano, which are useful hooks for adding recording logic