### PR TITLE
make Piano use activeNotes prop for initial state

### DIFF
--- a/src/Piano.js
+++ b/src/Piano.js
@@ -27,7 +27,7 @@ class Piano extends React.Component {
   };
 
   state = {
-    activeNotes: [],
+    activeNotes: this.props.activeNotes || [],
   };
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
This fixes the issue where the `activeNotes` prop is ignored on the initial state of `Piano`

[GitHub issue link](https://github.com/iqnivek/react-piano/issues/39)