### PR TITLE
Responsive Aspect-Ratio Sizing with padding-top css Technique

### DIFF
--- a/src/ControlledPiano.js
+++ b/src/ControlledPiano.js
@@ -26,6 +26,7 @@ class ControlledPiano extends React.Component {
   };
 
   static defaultProps = {
+    keyWidthToHeight: 0.33,
     renderNoteLabel: ({ keyboardShortcut, midiNumber, isActive, isAccidental }) =>
       keyboardShortcut ? (
         <div
@@ -159,9 +160,18 @@ class ControlledPiano extends React.Component {
   };
 
   render() {
+    const whiteKeysPerOctave = 7;
+    const totalKeysPerOctave = 12;
+    const keyCount = this.props.noteRange.last - this.props.noteRange.first;
+    const octaves = keyCount / totalKeysPerOctave;
+    const keyboardWidthToHeight = this.props.keyWidthToHeight * whiteKeysPerOctave * octaves;
+    const style = this.props.width
+      ? { width: '100%', height: '100%' }
+      : { position: 'relative', height: 0, paddingTop: `${(1 / keyboardWidthToHeight) * 100}%` };
+
     return (
       <div
-        style={{ width: '100%', height: '100%' }}
+        style={style}
         onMouseDown={this.onMouseDown}
         onMouseUp={this.onMouseUp}
         onTouchStart={this.onTouchStart}

--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -61,11 +61,11 @@ class Keyboard extends React.Component {
 
   render() {
     const naturalKeyWidth = this.getNaturalKeyWidth();
+    const style = this.props.width
+      ? { width: this.getWidth(), height: this.getHeight() }
+      : { width: this.getWidth(), height: this.getHeight(), position: 'absolute', top: 0, left: 0 };
     return (
-      <div
-        className={classNames('ReactPiano__Keyboard', this.props.className)}
-        style={{ width: this.getWidth(), height: this.getHeight() }}
-      >
+      <div className={classNames('ReactPiano__Keyboard', this.props.className)} style={style}>
         {this.getMidiNumbers().map((midiNumber) => {
           const { note, isAccidental } = MidiNumbers.getAttributes(midiNumber);
           const isActive = this.props.activeNotes.includes(midiNumber);


### PR DESCRIPTION
This PR shows how the styles on the `div`s of `ControlledPiano` and `Piano` could be adapted to responsively resize the keyboard without resorting to the `DimensionsProvider` workaround. It uses the [padding-top css Technique](https://css-tricks.com/aspect-ratio-boxes/).

I'm aware that this PR could be improved a little before merge, I just wanted to ask if you were open to this technique of responsive resizing. Especially functions from `Keyboard.js` could be extracted to be usable from `ControlledPiano.js` as well, as the latter needs to know and set the aspect ratio on the container `div`.